### PR TITLE
Basic AWS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.json
 config.test.json
 data
+firewall-adapter

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /go/src/github.com/ernestio/firewall-adapter
 
 RUN make deps && go install
 
-ENTRYPOINT /go/bin/firewall-adapter
+ENTRYPOINT ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+echo "Waiting for NATS"
+while ! echo exit | nc nats 4222; do sleep 1; done
+
+echo "Waiting for Postgres"
+while ! echo exit | nc postgres 5432; do sleep 1; done
+
+echo "Starting firewall-adapter"
+/go/bin/firewall-adapter

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func getConnectorTypes(ctype string) []string {
 	return connectors[ctype]
 }
 
-func main() {
+func setup() {
 	nc = ecc.NewConfig(os.Getenv("NATS_URI")).Nats()
 
 	c := o.Config{
@@ -50,9 +50,13 @@ func main() {
 	}
 
 	log.Println("Setting up firewalls")
-	o.StandardSubscription(&c, "firewall.create", "datacenter_type")
-	o.StandardSubscription(&c, "firewall.update", "datacenter_type")
-	o.StandardSubscription(&c, "firewall.delete", "datacenter_type")
+	t := Translator{}
+	o.TranslatedSubscription(&c, "firewall.create", "_type", t)
+	o.TranslatedSubscription(&c, "firewall.update", "_type", t)
+	o.TranslatedSubscription(&c, "firewall.delete", "_type", t)
+}
 
+func main() {
+	setup()
 	runtime.Goexit()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -38,10 +38,10 @@ func TestBasicRedirections(t *testing.T) {
 		chvcl := make(chan bool)
 
 		n.Subscribe("config.get.connectors", func(msg *nats.Msg) {
-			n.Publish(msg.Reply, []byte(`{"executions":["fake","salt"],"firewalls":["fake","vcloud"],"instances":["fake","vcloud"],"nats":["fake","vcloud"],"networks":["fake","vcloud"],"routers":["fake","vcloud"]}`))
+			n.Publish(msg.Reply, []byte(`{"firewalls":["fake","vcloud","vcloud-fake","aws","aws-fake"]}`))
 		})
 
-		go main()
+		setup()
 
 		n.Subscribe("firewall.create.fake", func(msg *nats.Msg) {
 			chfak <- true
@@ -54,8 +54,8 @@ func TestBasicRedirections(t *testing.T) {
 		})
 		Convey("When it receives an invalid fake message", func() {
 			n.Publish("firewall.create", []byte(`{"service":"aaa"}`))
-			Convey("Then it should redirect it to a fake connector", func() {
-				So(wait(cherr), ShouldNotBeNil)
+			Convey("Then it should redirect it to firewall error creation", func() {
+				So(wait(cherr), ShouldBeNil)
 			})
 		})
 		Convey("When it receives a valid fake message", func() {

--- a/translator.go
+++ b/translator.go
@@ -1,0 +1,247 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+)
+
+type rule struct {
+	Type            string `json:"type"`
+	SourceIP        string `json:"source_ip"`
+	SourcePort      string `json:"source_port"`
+	DestinationIP   string `json:"destination_ip"`
+	DestinationPort string `json:"destination_port"`
+	Protocol        string `json:"protocol"`
+}
+
+type builderEvent struct {
+	Uuid                  string `json:"_uuid"`
+	BatchID               string `json:"_batch_id"`
+	Type                  string `json:"type"`
+	Service               string `json:"service"`
+	Name                  string `json:"name"`
+	Rules                 []rule `json:"rules"`
+	RouterName            string `json:"router_name"`
+	RouterType            string `json:"router_type"`
+	RouterIP              string `json:"router_ip"`
+	ClientName            string `json:"client_name"`
+	DatacenterName        string `json:"datacenter_name"`
+	DatacenterPassword    string `json:"datacenter_password"`
+	DatacenterRegion      string `json:"datacenter_region"`
+	DatacenterType        string `json:"datacenter_type"`
+	DatacenterUsername    string `json:"datacenter_username"`
+	DatacenterAccessToken string `json:"datacenter_token"`
+	DatacenterAccessKey   string `json:"datacenter_secret"`
+	NetworkName           string `json:"network_name"`
+	SecurityGroupAWSIDs   string `json:"security_group_aws_ids"`
+	VCloudURL             string `json:"vcloud_url"`
+	Status                string `json:"status"`
+	ErrorCode             string `json:"error_code"`
+	ErrorMessage          string `json:"error_message"`
+}
+
+type vcloudEvent struct {
+	Uuid               string `json:"_uuid"`
+	BatchID            string `json:"_batch_id"`
+	Type               string `json:"_type"`
+	Service            string `json:"service_id"`
+	FirewallType       string `json:"firewall_type"`
+	Name               string `json:"firewall_name"`
+	Rules              []rule `json:"firewall_rules"`
+	RouterName         string `json:"router_name"`
+	RouterType         string `json:"router_type"`
+	RouterIP           string `json:"router_ip"`
+	ClientName         string `json:"client_name"`
+	DatacenterName     string `json:"datacenter_name"`
+	DatacenterPassword string `json:"datacenter_password"`
+	DatacenterRegion   string `json:"datacenter_region"`
+	DatacenterType     string `json:"datacenter_type"`
+	DatacenterUsername string `json:"datacenter_username"`
+	NetworkName        string `json:"network_name"`
+	VCloudURL          string `json:"vcloud_url"`
+	Status             string `json:"status"`
+	ErrorCode          string `json:"error_code"`
+	ErrorMessage       string `json:"error_message"`
+}
+
+type awsRule struct {
+	Destination string `json:"destination_ip"`
+	From        int    `json:"from_port"`
+	To          int    `json:"to_port"`
+}
+
+type awsEvent struct {
+	Uuid                  string `json:"_uuid"`
+	BatchID               string `json:"_batch_id"`
+	Type                  string `json:"_type"`
+	DatacenterRegion      string `json:"datacenter_region"`
+	DatacenterAccessToken string `json:"datacenter_access_token"`
+	DatacenterAccessKey   string `json:"datacenter_access_key"`
+	DatacenterVPCID       string `json:"datacenter_vpc_id"`
+	SecurityGroupName     string `json:"security_group_name"`
+	SecurityGroupAWSIDs   string `json:"security_group_aws_ids"`
+	SecurityGroupRules    struct {
+		Ingress []awsRule `json:"ingress"`
+		Engress []awsRule `json:"engress"`
+	} `json:"security_group_rules"`
+	Status       string `json:"status"`
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+}
+
+type Translator struct{}
+
+func (t Translator) BuilderToConnector(j []byte) []byte {
+	var input builderEvent
+	var output []byte
+	json.Unmarshal(j, &input)
+
+	switch input.DatacenterType {
+	case "vcloud", "fake-vcloud", "fake":
+		output = t.builderToVCloudConnector(input)
+	case "aws", "fake-aws":
+		output = t.builderToAwsConnector(input)
+	}
+
+	return output
+}
+
+func (t Translator) builderToVCloudConnector(input builderEvent) []byte {
+	var output vcloudEvent
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Service = input.Service
+	output.Type = input.DatacenterType
+	output.Name = input.Name
+	output.Rules = input.Rules
+	output.FirewallType = "vcloud"
+	output.RouterIP = input.RouterIP
+	output.RouterName = input.RouterName
+	output.RouterType = input.RouterType
+	output.NetworkName = input.NetworkName
+	output.ClientName = input.ClientName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterType = input.DatacenterType
+	output.VCloudURL = input.VCloudURL
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
+
+	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) builderToAwsConnector(input builderEvent) []byte {
+	var output awsEvent
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.DatacenterType
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterAccessToken = input.DatacenterAccessToken
+	output.DatacenterAccessKey = input.DatacenterAccessKey
+	output.DatacenterVPCID = input.DatacenterName
+	output.SecurityGroupName = input.Name
+	for _, r := range input.Rules {
+		from, _ := strconv.Atoi(r.SourcePort)
+		to, _ := strconv.Atoi(r.DestinationPort)
+		rule := awsRule{
+			Destination: r.DestinationIP,
+			From:        from,
+			To:          to,
+		}
+		if r.Type == "ingress" {
+			output.SecurityGroupRules.Ingress = append(output.SecurityGroupRules.Ingress, rule)
+		} else {
+			output.SecurityGroupRules.Engress = append(output.SecurityGroupRules.Engress, rule)
+		}
+	}
+
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
+
+	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) ConnectorToBuilder(j []byte) []byte {
+	var output []byte
+	var input map[string]interface{}
+
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.Decode(&input)
+
+	switch input["_type"] {
+	case "vcloud", "fake-vcloud", "fake":
+		output = t.vcloudConnectorToBuilder(j)
+	case "aws", "fake-aws":
+		output = t.awsConnectorToBuilder(j)
+	}
+
+	return output
+}
+
+func (t Translator) vcloudConnectorToBuilder(j []byte) []byte {
+	var input vcloudEvent
+	var output builderEvent
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.RouterType = input.Type
+	output.Name = input.Name
+	output.Rules = input.Rules
+	output.RouterIP = input.RouterIP
+	output.RouterName = input.RouterName
+	output.RouterType = input.RouterType
+	output.NetworkName = input.NetworkName
+	output.ClientName = input.ClientName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterType = input.DatacenterType
+	output.VCloudURL = input.VCloudURL
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
+
+	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) awsConnectorToBuilder(j []byte) []byte {
+	var input awsEvent
+	var output builderEvent
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.Type
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterAccessToken = input.DatacenterAccessToken
+	output.DatacenterAccessKey = input.DatacenterAccessKey
+	output.DatacenterName = input.DatacenterVPCID
+	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
+	// TODO Rules
+	output.Status = input.Status
+	output.ErrorCode = input.ErrorCode
+	output.ErrorMessage = input.ErrorMessage
+
+	body, _ := json.Marshal(output)
+
+	return body
+}

--- a/translator.go
+++ b/translator.go
@@ -254,7 +254,7 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 		from := strconv.Itoa(r.From)
 		to := strconv.Itoa(r.To)
 		output.Rules = append(output.Rules, rule{
-			Type:            "ingress",
+			Type:            "egress",
 			SourceIP:        r.IP,
 			SourcePort:      from,
 			DestinationPort: to,

--- a/translator.go
+++ b/translator.go
@@ -102,9 +102,9 @@ func (t Translator) BuilderToConnector(j []byte) []byte {
 	json.Unmarshal(j, &input)
 
 	switch input.DatacenterType {
-	case "vcloud", "fake-vcloud", "fake":
+	case "vcloud", "vcloud-fake", "fake":
 		output = t.builderToVCloudConnector(input)
-	case "aws", "fake-aws":
+	case "aws", "aws-fake":
 		output = t.builderToAwsConnector(input)
 	}
 
@@ -184,9 +184,9 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	dec.Decode(&input)
 
 	switch input["_type"] {
-	case "vcloud", "fake-vcloud", "fake":
+	case "vcloud", "vcloud-fake", "fake":
 		output = t.vcloudConnectorToBuilder(j)
-	case "aws", "fake-aws":
+	case "aws", "aws-fake":
 		output = t.awsConnectorToBuilder(j)
 	}
 

--- a/translator.go
+++ b/translator.go
@@ -157,9 +157,10 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 		from, _ := strconv.Atoi(r.SourcePort)
 		to, _ := strconv.Atoi(r.DestinationPort)
 		rule := awsRule{
-			IP:   r.SourceIP,
-			From: from,
-			To:   to,
+			IP:       r.SourceIP,
+			From:     from,
+			To:       to,
+			Protocol: r.Protocol,
 		}
 		if r.Type == "ingress" {
 			output.SecurityGroupRules.Ingress = append(output.SecurityGroupRules.Ingress, rule)

--- a/translator.go
+++ b/translator.go
@@ -90,9 +90,7 @@ type awsEvent struct {
 		Ingress []awsRule `json:"ingress"`
 		Egress  []awsRule `json:"egress"`
 	} `json:"security_group_rules"`
-	Status       string `json:"status"`
-	ErrorCode    string `json:"error_code"`
-	ErrorMessage string `json:"error_message"`
+	ErrorMessage string `json:"error"`
 }
 
 type Translator struct{}
@@ -170,10 +168,6 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 		}
 	}
 
-	output.Status = input.Status
-	output.ErrorCode = input.ErrorCode
-	output.ErrorMessage = input.ErrorMessage
-
 	body, _ := json.Marshal(output)
 
 	return body
@@ -217,9 +211,12 @@ func (t Translator) vcloudConnectorToBuilder(j []byte) []byte {
 	output.DatacenterPassword = input.DatacenterPassword
 	output.DatacenterType = input.DatacenterType
 	output.VCloudURL = input.VCloudURL
-	output.Status = input.Status
-	output.ErrorCode = input.ErrorCode
-	output.ErrorMessage = input.ErrorMessage
+
+	if input.ErrorMessage != "" {
+		output.Status = "errored"
+		output.ErrorCode = "0"
+		output.ErrorMessage = input.ErrorMessage
+	}
 
 	body, _ := json.Marshal(output)
 
@@ -264,9 +261,11 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 		})
 	}
 
-	output.Status = input.Status
-	output.ErrorCode = input.ErrorCode
-	output.ErrorMessage = input.ErrorMessage
+	if input.ErrorMessage != "" {
+		output.Status = "errored"
+		output.ErrorCode = "0"
+		output.ErrorMessage = input.ErrorMessage
+	}
 
 	body, _ := json.Marshal(output)
 

--- a/translator.go
+++ b/translator.go
@@ -38,7 +38,7 @@ type builderEvent struct {
 	DatacenterAccessToken string `json:"datacenter_token"`
 	DatacenterAccessKey   string `json:"datacenter_secret"`
 	NetworkName           string `json:"network_name"`
-	SecurityGroupAWSIDs   string `json:"security_group_aws_ids"`
+	SecurityGroupAWSID    string `json:"security_group_aws_id"`
 	VCloudURL             string `json:"vcloud_url"`
 	Status                string `json:"status"`
 	ErrorCode             string `json:"error_code"`
@@ -85,7 +85,7 @@ type awsEvent struct {
 	DatacenterAccessKey   string `json:"datacenter_access_key"`
 	DatacenterVPCID       string `json:"datacenter_vpc_id"`
 	SecurityGroupName     string `json:"security_group_name"`
-	SecurityGroupAWSIDs   string `json:"security_group_aws_ids"`
+	SecurityGroupAWSID    string `json:"security_group_aws_id"`
 	SecurityGroupRules    struct {
 		Ingress []awsRule `json:"ingress"`
 		Egress  []awsRule `json:"egress"`
@@ -152,6 +152,7 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 	output.DatacenterAccessToken = input.DatacenterAccessToken
 	output.DatacenterAccessKey = input.DatacenterAccessKey
 	output.DatacenterVPCID = input.DatacenterName
+	output.SecurityGroupAWSID = input.SecurityGroupAWSID
 	output.SecurityGroupName = input.Name
 	for _, r := range input.Rules {
 		from, _ := strconv.Atoi(r.SourcePort)
@@ -237,7 +238,7 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 	output.DatacenterAccessToken = input.DatacenterAccessToken
 	output.DatacenterAccessKey = input.DatacenterAccessKey
 	output.DatacenterName = input.DatacenterVPCID
-	output.SecurityGroupAWSIDs = input.SecurityGroupAWSIDs
+	output.SecurityGroupAWSID = input.SecurityGroupAWSID
 
 	for _, r := range input.SecurityGroupRules.Ingress {
 		from := strconv.Itoa(r.From)


### PR DESCRIPTION
Adapters were conceived as the place to prepare an internal service to be consumed by a connector, so connectors can focus only on calling third party apis.

However they are quite dummy at the moment, they only get a message and redirect it to the consumer related to the provider.

The behaviour implemented here is:

- Have defined a connector mapping for each connector they support.
- Receive a message "component.process" with the related component partial of the service as this one.
- Call connector with a "component.process.provider"
- Receive a "component.process.provider.done" and map the result back to the partial of the service.
- And finally publish "component.process.done" with mapped partial.